### PR TITLE
[449766] Whitespace characters in Android SDK path are not supported

### DIFF
--- a/plugins/org.eclipse.thym.android.core/src/org/eclipse/thym/android/core/adt/AndroidSDKManager.java
+++ b/plugins/org.eclipse.thym.android.core/src/org/eclipse/thym/android/core/adt/AndroidSDKManager.java
@@ -440,23 +440,25 @@ public class AndroidSDKManager {
 	}
 	
 	private String getAndroidCommand(){
-		if(isWindows()){
-			return "cmd /c "+ toolsDir +"android";
-		}
-		return toolsDir+"android";
+		String command = addQuotes(toolsDir+"android");
+		return isWindows() ? "cmd /c "+ command : command;
 	}
 	
 	private String getADBCommand(){
-		return platformTools+"adb";
+		return addQuotes(platformTools+"adb");
 	}
 	
 	private String getEmulatorCommand(){
-		return toolsDir+"emulator";
+		return addQuotes(toolsDir+"emulator");
 	}
 	
 	private boolean isWindows(){
 		String OS = System.getProperty("os.name","unknown");
 		return OS.toLowerCase().indexOf("win")>-1;
+	}
+	
+	private String addQuotes(String path) {
+		return "\"" + path + "\"";
 	}
 	
 }


### PR DESCRIPTION
Android support does not work correctly if there are whitespace
characters in Android SDK path.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=449766
Change-Id: I70ba4d6fa00eea1540ba59fe62fd55dfa8404c56
Signed-off-by: wgalanciak wojciech.galanciak@gmail.com
