### PR TITLE
Outline isn't displayed when opening Cordova Configuration editor

### DIFF
--- a/plugins/org.eclipse.thym.ui/src/org/eclipse/thym/ui/config/internal/ConfigEditor.java
+++ b/plugins/org.eclipse.thym.ui/src/org/eclipse/thym/ui/config/internal/ConfigEditor.java
@@ -68,6 +68,15 @@ public class ConfigEditor extends FormEditor {
 	}
 
 	@Override
+	public Object getAdapter(Class adapter) {
+		Object object = super.getAdapter(adapter);
+		if (object != null) {
+			return object;
+		}
+		return (sourceEditor != null) ? sourceEditor.getAdapter(adapter) : null;
+	}
+
+	@Override
 	public void doSave(IProgressMonitor monitor) {
 		sourceEditor.doSave(monitor);
 	}


### PR DESCRIPTION
Bug 447348 - Outline isn't displayed when opening Cordova Configuration editor
Signed-off-by: Snjezana Peco snjeza.peco@gmail.com
