### PR TITLE
[453991] Cannot build Andorid application without android-19 target

### DIFF
--- a/plugins/org.eclipse.thym.android.core/src/org/eclipse/thym/android/core/adt/AndroidProjectUtils.java
+++ b/plugins/org.eclipse.thym.android.core/src/org/eclipse/thym/android/core/adt/AndroidProjectUtils.java
@@ -68,7 +68,7 @@ public class AndroidProjectUtils {
 				AndroidSDKManager sdkManager = AndroidSDKManager.getManager();
 				List<AndroidSDK> targets = sdkManager.listTargets();
 				for (AndroidSDK androidSDK : targets) {
-					if(alc.compare(targetValue, androidSDK.getApiLevel())==0){
+					if(alc.compare(targetValue, androidSDK.getApiLevel())<=0){
 						return androidSDK;
 					}
 				}


### PR DESCRIPTION
Select a higher or equal target to minimum required API level defined in
a project.properties file.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=453991
Signed-off-by: wgalanciak wojciech.galanciak@gmail.com
