### PR TITLE
Log message columns in Error Log View have wrong content

### DIFF
--- a/plugins/org.eclipse.thym.ui/src/org/eclipse/thym/ui/HybridUI.java
+++ b/plugins/org.eclipse.thym.ui/src/org/eclipse/thym/ui/HybridUI.java
@@ -99,7 +99,7 @@ public class HybridUI extends AbstractUIPlugin {
 	}
 	
 	public static void log(int status, String message, Throwable throwable ){
-		logger.log(new Status(status, message, PLUGIN_ID,throwable));
+		logger.log(new Status(status, PLUGIN_ID, message, throwable));
 	}
 	
 	/**


### PR DESCRIPTION
Fix changes Status constructor arguments to have right plug-in id and
description column contents

Signed-off-by: Denis Golovin dgolovin@gmail.com
