### PR TITLE
[457324] Error on launching Android emulator

### DIFF
--- a/plugins/org.eclipse.thym.android.core/src/org/eclipse/thym/android/core/adt/AndroidSDKManager.java
+++ b/plugins/org.eclipse.thym.android.core/src/org/eclipse/thym/android/core/adt/AndroidSDKManager.java
@@ -441,7 +441,7 @@ public class AndroidSDKManager {
 	
 	private String getAndroidCommand(){
 		String command = "android";
-		return isWindows() ? "cmd /c " + command : command; 
+		return isWindows() ? "cmd /c " + command :  "./" + command; 
 	}
 	
 	private String getADBCommand(){

--- a/plugins/org.eclipse.thym.android.core/src/org/eclipse/thym/android/core/adt/AndroidSDKManager.java
+++ b/plugins/org.eclipse.thym.android.core/src/org/eclipse/thym/android/core/adt/AndroidSDKManager.java
@@ -290,13 +290,13 @@ public class AndroidSDKManager {
 		command.append(getAndroidCommand());
 		command.append(" create project");
 		command.append(" --target ").append(target.getId());
-		command.append(" --path ").append('"').append(path.getPath()).append('"');
-		command.append(" --name ").append('"').append(projectName).append('"');
+		command.append(" --path ").append(addQuotes(path.getPath()));
+		command.append(" --name ").append(addQuotes(projectName));
 		command.append(" --activity ").append(activity);
 		command.append(" --package ").append(packageName);
 
 		CreateProjectResultParser parser = new CreateProjectResultParser();
-		processUtility.execSync(command.toString(), null, parser, parser, monitor, null, null);
+		processUtility.execSync(command.toString(), new File(toolsDir), parser, parser, monitor, null, null);
 		if( !monitor.isCanceled() && parser.getErrorString() != null ){
 			throw new CoreException(new Status(IStatus.ERROR,AndroidCore.PLUGIN_ID,"Error creating the Android project: "+ parser.getErrorString()));
 		}
@@ -321,7 +321,7 @@ public class AndroidSDKManager {
 		command.append(" --path ").append('"').append(path.getPath()).append('"');
 		ExternalProcessUtility processUtility = new ExternalProcessUtility();
 		CreateProjectResultParser parser = new CreateProjectResultParser();
-		processUtility.execSync(command.toString(), null, parser, parser, monitor, null, null);
+		processUtility.execSync(command.toString(), new File(toolsDir), parser, parser, monitor, null, null);
 		if( !monitor.isCanceled() && parser.getErrorString() != null ){
 			throw new CoreException(new Status(IStatus.ERROR,AndroidCore.PLUGIN_ID,"Error creating the Android project: "+ parser.getErrorString()));
 		}
@@ -340,7 +340,7 @@ public class AndroidSDKManager {
 	public List<AndroidAVD> listAVDs() throws CoreException{
 		ExternalProcessUtility processUtility = new ExternalProcessUtility();
 		AVDListParser parser = new AVDListParser();
-		processUtility.execSync(getAndroidCommand()+" list avd", null, parser, parser, 
+		processUtility.execSync(getAndroidCommand()+" list avd", new File(toolsDir), parser, parser, 
 				new NullProgressMonitor(), null, null);
 		return parser.getAVDList();
 	}
@@ -349,7 +349,7 @@ public class AndroidSDKManager {
 		ExternalProcessUtility processUtility = new ExternalProcessUtility();
 		TargetListParser parser = new TargetListParser();
 		processUtility.execSync(getAndroidCommand()+" list target", 
-				null, parser, parser, new NullProgressMonitor(), null, null);
+				new File(toolsDir), parser, parser, new NullProgressMonitor(), null, null);
 		return parser.getSDKList();
 	}
 	
@@ -436,12 +436,12 @@ public class AndroidSDKManager {
 		ExternalProcessUtility processUtility = new ExternalProcessUtility();
 		StringBuilder command = new StringBuilder(getAndroidCommand());
 		command.append(" avd ");
-		processUtility.execAsync(command.toString(), null, null, null, null);
+		processUtility.execAsync(command.toString(), new File(toolsDir), null, null, null);
 	}
 	
 	private String getAndroidCommand(){
-		String command = addQuotes(toolsDir+"android");
-		return isWindows() ? "cmd /c "+ command : command;
+		String command = "android";
+		return isWindows() ? "cmd /c " + command : command; 
 	}
 	
 	private String getADBCommand(){


### PR DESCRIPTION
The problem appears only when there are whitespaces in Eclipse's
location. The result is that create Andorid project command fails. The
solution is to execute android command from its location by setting a
proper working directory.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=457324
Change-Id: I07e0a580be03b89fb6f6aa2a11ecfb3c1b98358c
Signed-off-by: wgalanciak <wojciech.galanciak@gmail.com>