### PR TITLE
Bug 455331 - Cannot build wp8 app - msbuild failed

### DIFF
--- a/plugins/org.eclipse.thym.core/src/org/eclipse/thym/core/internal/util/ExternalProcessUtility.java
+++ b/plugins/org.eclipse.thym.core/src/org/eclipse/thym/core/internal/util/ExternalProcessUtility.java
@@ -58,7 +58,7 @@ public class ExternalProcessUtility {
 		}
 	}
 	
-	public void execSync ( String commandLine, File workingDirectory, 
+	public int execSync ( String commandLine, File workingDirectory, 
 			IStreamListener outStreamListener, 
 			IStreamListener errorStreamListener, IProgressMonitor monitor, String[] envp, ILaunchConfiguration launchConfiguration) throws CoreException{
 		
@@ -101,6 +101,7 @@ public class ExternalProcessUtility {
 				HybridCore.log(IStatus.INFO, "Exception waiting for process to terminate", e);
 			}
 		}
+		return prcs.getExitValue();
 	}	
 	
 	

--- a/plugins/org.eclipse.thym.wp.core/src/org/eclipse/thym/wp/core/vstudio/MSBuild.java
+++ b/plugins/org.eclipse.thym.wp.core/src/org/eclipse/thym/wp/core/vstudio/MSBuild.java
@@ -23,7 +23,6 @@ import org.eclipse.core.runtime.SubProgressMonitor;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.thym.core.HybridProject;
 import org.eclipse.thym.core.internal.util.ExternalProcessUtility;
-import org.eclipse.thym.core.internal.util.TextDetectingStreamListener;
 import org.eclipse.thym.core.platform.AbstractNativeBinaryBuildDelegate;
 import org.eclipse.thym.wp.core.WPCore;
 import org.eclipse.thym.wp.internal.core.Messages;
@@ -185,12 +184,10 @@ public class MSBuild extends AbstractNativeBinaryBuildDelegate {
 					return;
 				}
 				monitor.worked(1);
-				TextDetectingStreamListener listener = new TextDetectingStreamListener(
-						"Build succeeded."); //$NON-NLS-1$
-				processUtility.execSync(cmdString.toString(), projectLocation,
-						listener, listener, monitor, null,
+				int ret = processUtility.execSync(cmdString.toString(), projectLocation,
+						null, null, monitor, null,
 						getLaunchConfiguration());
-				if (!listener.isTextDetected()) {
+				if (ret != 0) {
 					throw new CoreException(new Status(IStatus.ERROR,
 							WPCore.PLUGIN_ID, Messages.MSBuild_MSBuildError));
 				}


### PR DESCRIPTION
The problem of https://bugs.eclipse.org/bugs/show_bug.cgi?id=455331 is by using TextDetectingStreamListener. It means that it basically waits until the string "Build succeeded" appears. However if you have OS in another language than in english, then msbuild.exe produces localized messages and the condition will never be fulfilled. I've rewritten the code that it uses return values from msbuild.exe.