### PR TITLE
Bug 472059 - OS-specific plugins installed on all OS types

### DIFF
--- a/features/org.eclipse.thym.feature/feature.xml
+++ b/features/org.eclipse.thym.feature/feature.xml
@@ -26,6 +26,7 @@
 
    <plugin
          id="org.eclipse.thym.ios.core"
+         os="macosx"
          download-size="0"
          install-size="0"
          version="0.0.0"
@@ -33,6 +34,7 @@
 
    <plugin
          id="org.eclipse.thym.ios.ui"
+         os="macosx"
          download-size="0"
          install-size="0"
          version="0.0.0"


### PR DESCRIPTION
Added filter in the Thym feature to install iOS-specific plugins only on
Mac OS X.

Signed-off-by: Kaloyan Raev <kaloyan.r@zend.com>