### PR TITLE
Relax version range for Easymport

### DIFF
--- a/plugins/org.eclipse.thym.ui.importer/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.thym.ui.importer/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Smart Import support for THyM
 Bundle-SymbolicName: org.eclipse.thym.ui.importer;singleton:=true
 Bundle-Version: 0.0.1.qualifier
 Bundle-Vendor: Eclipse.org
-Require-Bundle: org.eclipse.e4.ui.importer;bundle-version="0.2.0",
+Require-Bundle: org.eclipse.e4.ui.importer,
  org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.core.resources,


### PR DESCRIPTION
Changes in Easymport make clients (such as Thym)
backward-compatible at execution time, so no need
to have a too strict version range.