### PR TITLE
Added test requirement for network when there is a proxy

### DIFF
--- a/tests/org.eclipse.thym.ui.importer.test/pom.xml
+++ b/tests/org.eclipse.thym.ui.importer.test/pom.xml
@@ -24,6 +24,13 @@
 				<artifactId>tycho-surefire-plugin</artifactId>
 				<configuration>
 					<useUIHarness>true</useUIHarness>
+					<dependencies>
+  					<dependency>
+  						<!-- To resolve proxy settings -->
+  						<artifactId>org.eclipse.platform.feature.group</artifactId>
+  						<type>p2-installable-unit</type>
+  					</dependency>
+  				</dependencies>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
Typically for hudson.eclipse.org, we need to be able to deal with
the proxy. Adding the Platform feature adds the necessary
org.eclipse.core.net.* fragments.