### PR TITLE
Ship smart import support with main feature

### DIFF
--- a/features/org.eclipse.thym.feature/feature.xml
+++ b/features/org.eclipse.thym.feature/feature.xml
@@ -48,6 +48,13 @@
          unpack="false"/>
 
    <plugin
+         id="org.eclipse.thym.ui.importer"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.eclipse.thym.android.core"
          download-size="0"
          install-size="0"

--- a/plugins/org.eclipse.thym.ui.importer/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.thym.ui.importer/META-INF/MANIFEST.MF
@@ -2,12 +2,12 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Smart Import support for THyM
 Bundle-SymbolicName: org.eclipse.thym.ui.importer;singleton:=true
-Bundle-Version: 0.0.1.qualifier
+Bundle-Version: 2.0.0.qualifier
 Bundle-Vendor: Eclipse.org
-Require-Bundle: org.eclipse.ui;bundle-version="3.12.0",
+Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.core.resources,
- org.eclipse.ui.ide,
+ org.eclipse.ui.ide;bundle-version="3.12.0",
  org.eclipse.wst.jsdt.core;bundle-version="1.3.100",
  org.eclipse.ui.navigator.resources,
  org.eclipse.ui.navigator,

--- a/repository/category.xml
+++ b/repository/category.xml
@@ -8,11 +8,4 @@
       <category name="THyM"/>
    </feature>
    
-   <category-def name="THyM.incubator" label="Eclipse THyM: Incubating and Experimental plugins"/>
-   <bundle id="org.eclipse.thym.ui.importer" version="0.0.0">
-     <category name="THyM.incubator"/>
-   </bundle>
-   <bundle id="org.eclipse.thym.ui.importer.source" version="0.0.0">
-     <category name="THyM.incubator"/>
-   </bundle>
 </site>


### PR DESCRIPTION
The Smart Importer framework is shipped as part of Platform
with Neon. It's now better to ship Thym as a part of the main
feature.