### PR TITLE
Bug 462185 - Adopt new plugin syntax for config.xml

### DIFF
--- a/plugins/org.eclipse.thym.core/src/org/eclipse/thym/core/config/Plugin.java
+++ b/plugins/org.eclipse.thym.core/src/org/eclipse/thym/core/config/Plugin.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * 	Contributors:
+ * 		 Red Hat Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+
+package org.eclipse.thym.core.config;
+
+import static org.eclipse.thym.core.config.WidgetModelConstants.PLUGIN_ATTR_NAME;
+import static org.eclipse.thym.core.config.WidgetModelConstants.PLUGIN_ATTR_SPEC;
+
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+/**
+ * Plugin tag in config.xml
+ *
+ * @author Angel Misevski
+ *
+ */
+public class Plugin extends AbstractConfigObject {
+
+	private Property<String> name = new Property<String>(PLUGIN_ATTR_NAME);
+	private Property<String> spec = new Property<String>(PLUGIN_ATTR_SPEC);
+
+	Plugin(Node node) {
+		this.itemNode = (Element) node;
+		name.setValue(getNodeAttribute(node, null, PLUGIN_ATTR_NAME));
+		spec.setValue(getNodeAttribute(node, null, PLUGIN_ATTR_SPEC));
+	}
+
+	public String getName() {
+		return name.getValue();
+	}
+
+	public String getSpec() {
+		return spec.getValue();
+	}
+
+	public void setName(String name) {
+		setAttributeValue(itemNode, null, PLUGIN_ATTR_NAME, name);
+		this.name.setValue(name);
+	}
+
+	public void setSpec(String spec) {
+		setAttributeValue(itemNode, null, PLUGIN_ATTR_SPEC, spec);
+		this.spec.setValue(spec);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if(obj == null || !(obj instanceof Plugin))
+			return false;
+		if(obj == this )
+			return true;
+		Plugin that = (Plugin) obj;
+		return equalField(that.getName(), this.getName());
+	}
+
+	@Override
+	public int hashCode() {
+		int hash = super.hashCode();
+		if(getName() != null )
+			hash *= getName().hashCode();
+		return hash;
+	}
+}

--- a/plugins/org.eclipse.thym.core/src/org/eclipse/thym/core/config/Widget.java
+++ b/plugins/org.eclipse.thym.core/src/org/eclipse/thym/core/config/Widget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2014 Red Hat, Inc. 
+ * Copyright (c) 2013, 2016 Red Hat, Inc. 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -26,6 +26,7 @@ import static org.eclipse.thym.core.config.WidgetModelConstants.WIDGET_TAG_NAME;
 import static org.eclipse.thym.core.config.WidgetModelConstants.WIDGET_TAG_PREFERENCE;
 import static org.eclipse.thym.core.config.WidgetModelConstants.WIDGET_TAG_SPLASH;
 import static org.eclipse.thym.core.config.WidgetModelConstants.WIDGET_TAG_ENGINE;
+import static org.eclipse.thym.core.config.WidgetModelConstants.WIDGET_TAG_PLUGIN;
 
 import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
@@ -65,6 +66,7 @@ public class Widget extends AbstractConfigObject {
 	private Property<List<Icon>> icons = new Property<List<Icon>>("icons");
 	private Property<List<Splash>> splashes = new Property<List<Splash>>("splashes");
 	private Property<List<Engine>> engines = new Property<List<Engine>>("engines");
+	private Property<List<Plugin>> plugins = new Property<List<Plugin>>("plugins");
 	
 	/**
 	 * Creates a new instance from its xml representation.
@@ -101,6 +103,7 @@ public class Widget extends AbstractConfigObject {
 		loadListItem(WIDGET_TAG_ICON, null, node, icons, Icon.class);
 		loadListItem(WIDGET_TAG_SPLASH, null, node, splashes, Splash.class);
 		loadListItem(WIDGET_TAG_ENGINE, null, node, engines, Engine.class);
+		loadListItem(WIDGET_TAG_PLUGIN, null, node, plugins, Plugin.class);
 	}
 
 
@@ -223,6 +226,10 @@ public class Widget extends AbstractConfigObject {
 		return engines.getValue();
 	}
 	
+	public List<Plugin> getPlugins(){
+		return plugins.getValue();
+	}
+
 	public void setId(String id) {
 		this.id.setValue(id);
 		setAttributeValue(itemNode, null, WIDGET_ATTR_ID, id);
@@ -297,6 +304,10 @@ public class Widget extends AbstractConfigObject {
 		addItem(engine, engines);
 	}
 	
+	public void addPlugin(Plugin plugin){
+		addItem(plugin, plugins);
+	}
+
 	
 	public void removePreference( Preference preference){
 		removeItem(preference, this.preferences);
@@ -322,6 +333,10 @@ public class Widget extends AbstractConfigObject {
 		removeItem(engine, this.engines);
 	}
 	
+	public void removePlugin(Plugin plugin){
+		removeItem(plugin, this.plugins);
+	}
+
 	private <T extends AbstractConfigObject > void removeItem(T object, Property<List<T>> property){
 		if(object == null )
 			return;

--- a/plugins/org.eclipse.thym.core/src/org/eclipse/thym/core/config/WidgetModelConstants.java
+++ b/plugins/org.eclipse.thym.core/src/org/eclipse/thym/core/config/WidgetModelConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2013, 2015 Red Hat, Inc. 
+ * Copyright (c) 2013, 2016 Red Hat, Inc. 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -53,8 +53,8 @@ interface WidgetModelConstants {
     static final String IMAGERESOURCE_ATTR_SRC = "src";
     static final String LICENSE_ATTR_HREF = "href";
     static final String FEATURE_PARAM_TAG = "param";
-    static final String PLUGIN_ATTR_VERSION = "version";
     static final String PLUGIN_ATTR_NAME = "name";
+    static final String PLUGIN_ATTR_SPEC = "spec";
     static final String PARAM_ATTR_NAME = "name";
     static final String PARAM_ATTR_VALUE = "value";
     static final String PREFERENCE_ATTR_VALUE = "value";


### PR DESCRIPTION
Add Plugin class to represent <Plugin> tag in config.xml. Change
PropertiesPage to correctly show this new class, and hook existing
buttons to plugin management. Previous Feature class still exists,
but is no longer used.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=462185
Signed-off-by: Angel Misevski <amisevsk@redhat.com>