### PR TITLE
Bug 491580 - Implement Engines Management in config.xml editor

### DIFF
--- a/tests/org.eclipse.thym.test/src/org/eclipse/thym/hybrid/test/TestProject.java
+++ b/tests/org.eclipse.thym.test/src/org/eclipse/thym/hybrid/test/TestProject.java
@@ -16,6 +16,7 @@ import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
@@ -51,6 +52,13 @@ public class TestProject {
 			HybridProjectCreator projectCreator = new HybridProjectCreator();
 			projectCreator.createBasicTemplatedProject(PROJECT_NAME, null, APPLICATION_NAME, APPLICATION_ID, 
 					HybridMobileEngineManager.defaultEngines(), new NullProgressMonitor());
+
+			// Ensure the platforms folder exists; tests that write platforms.json fail otherwise.
+			IFolder platformsFolder = getProject().getFolder("/platforms");
+			if (!platformsFolder.exists()) {
+				platformsFolder.create(true, true, null);
+			}
+
 		} catch (CoreException e) {
 			e.printStackTrace();
 			throw new RuntimeException(e);


### PR DESCRIPTION
Fixes issues with tests running on platforms that do not have any cordova platforms installed.
Previously, the tests assumed that cordova-android 5.0.0 was installed; this has been changed
so that the tests should pass independent of the system's set up. Note that the changes
do result in the tests being more fragile, as they rely on side-effects of methods in
CordovaEngineProvider.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=491580
Signed-off-by: Angel Misevski <amisevsk@redhat.com>