### PR TITLE
[506123] - Config.xml is not saved after "Create Hybrid Mobile Applic…

### DIFF
--- a/plugins/org.eclipse.thym.ui/src/org/eclipse/thym/ui/config/internal/EssentialsPage.java
+++ b/plugins/org.eclipse.thym.ui/src/org/eclipse/thym/ui/config/internal/EssentialsPage.java
@@ -343,6 +343,8 @@ public class EssentialsPage extends AbstactConfigEditorPage implements IHyperlin
 		};
 
 		getWidget().addPropertyChangeListener("engines", engineListener);
+		
+		updateActiveEngines();
 
 		engineSection.addSelectionChangedListener(new ISelectionChangedListener() {
 
@@ -380,8 +382,6 @@ public class EssentialsPage extends AbstactConfigEditorPage implements IHyperlin
 				}
 			}
 		});
-
-		updateActiveEngines();
 	}
 
 	private void getEnginesFromWidget() {


### PR DESCRIPTION
…ation" wizard finished

Update active engines before selection listener is created.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=506123
Signed-off-by: Rastislav Wagner <rawagner@redhat.com>