### PR TITLE
[491430] Android SDK can be defined via preferences or via env var.

### DIFF
--- a/plugins/org.eclipse.thym.android.core/src/org/eclipse/thym/android/core/AndroidConstants.java
+++ b/plugins/org.eclipse.thym.android.core/src/org/eclipse/thym/android/core/AndroidConstants.java
@@ -31,5 +31,7 @@ public interface AndroidConstants {
 	
 	public static final int STATUS_CODE_ANDROID_SDK_NOT_DEFINED= 200;
 	public static final int STATUS_CODE_ANDROID_AVD_ISSUE= 210;
+	
+	public static final String ANDROID_HOME="ANDROID_HOME";
 
 }

--- a/plugins/org.eclipse.thym.android.core/src/org/eclipse/thym/android/core/AndroidCore.java
+++ b/plugins/org.eclipse.thym.android.core/src/org/eclipse/thym/android/core/AndroidCore.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package org.eclipse.thym.android.core;
 
+import java.io.File;
 import java.util.Hashtable;
 
 import org.eclipse.core.runtime.ILog;
@@ -60,8 +61,37 @@ public class AndroidCore implements BundleActivator, DebugOptionsListener {
 		AndroidCore.context = null;
 	}
 	
+	/**
+	 * Returns location of Android SDK defined in preferences. If SDK is not defined in preferences returns 
+	 * location from environment variable ANDROID_HOME. If location is not valid or is not defined, null is returned.
+	 * @return location of Android SDK or null if location is not valid
+	 */
 	public static String getSDKLocation(){
-		return Platform.getPreferencesService().getString("org.eclipse.thym.ui", AndroidConstants.PREF_ANDROID_SDK_LOCATION, null, null);
+		String prefSDKLocation =Platform.getPreferencesService().getString("org.eclipse.thym.ui", AndroidConstants.PREF_ANDROID_SDK_LOCATION, null, null);
+		if(isValidSDKLocation(prefSDKLocation)){
+			return prefSDKLocation;
+		}
+		String envSDKLocation = System.getenv(AndroidConstants.ANDROID_HOME);
+		if(isValidSDKLocation(envSDKLocation)){
+			return envSDKLocation;
+		}
+		return null;
+	}
+	
+	private static boolean isValidSDKLocation(String sdkLocation){
+		if(sdkLocation != null && !sdkLocation.isEmpty()){
+			File file = new File(sdkLocation);
+			if(!file.isDirectory()){
+				return false;
+			}
+			File toolsFolder = new File(file,"tools");
+			File platformToolsFolder = new File(file, "platform-tools");
+			if(!toolsFolder.isDirectory() || !platformToolsFolder.isDirectory()){
+				return false;
+			}
+			return true;
+		}
+		return false;
 	}
 	
 	public static void log(int status, String message, Throwable throwable ){

--- a/plugins/org.eclipse.thym.android.core/src/org/eclipse/thym/android/core/adt/BuildDelegate.java
+++ b/plugins/org.eclipse.thym.android.core/src/org/eclipse/thym/android/core/adt/BuildDelegate.java
@@ -10,6 +10,9 @@
  *******************************************************************************/
 package org.eclipse.thym.android.core.adt;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IResource;
@@ -20,6 +23,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.thym.android.core.AndroidConstants;
 import org.eclipse.thym.android.core.AndroidCore;
 import org.eclipse.thym.core.HybridProject;
 import org.eclipse.thym.core.internal.cordova.CordovaCLI;
@@ -50,8 +54,13 @@ public class BuildDelegate extends AbstractNativeBinaryBuildDelegate {
 			String buildType = "--debug";
 			if(isRelease()){
 				buildType = "--release";
-			}	
-			IStatus status = CordovaCLI.newCLIforProject(hybridProject).build(sm.newChild(70),"android",buildType).convertTo(ErrorDetectingCLIResult.class).asStatus();
+			}
+			Map<String,String> androidHome = null;
+			if(AndroidCore.getSDKLocation() != null){
+				androidHome = new HashMap<>();
+				androidHome.put(AndroidConstants.ANDROID_HOME, AndroidCore.getSDKLocation());
+			}
+			IStatus status = CordovaCLI.newCLIforProject(hybridProject,androidHome).build(sm.newChild(70),"android",buildType).convertTo(ErrorDetectingCLIResult.class).asStatus();
 			this.getProject().refreshLocal(IResource.DEPTH_INFINITE, sm.newChild(20));
 			if(status.getSeverity() == IStatus.ERROR){
 				throw new CoreException(status);

--- a/plugins/org.eclipse.thym.android.ui/src/org/eclipse/thym/android/ui/AndroidSimOptionsTab.java
+++ b/plugins/org.eclipse.thym.android.ui/src/org/eclipse/thym/android/ui/AndroidSimOptionsTab.java
@@ -36,10 +36,10 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.thym.android.core.AndroidConstants;
+import org.eclipse.thym.android.core.AndroidCore;
 import org.eclipse.thym.android.core.adt.AndroidAPILevelComparator;
 import org.eclipse.thym.android.core.adt.AndroidAVD;
 import org.eclipse.thym.android.core.adt.AndroidSDKManager;
-import org.eclipse.thym.android.ui.internal.statushandler.MissingSDKStatusHandler;
 import org.eclipse.ui.dialogs.ElementListSelectionDialog;
 import org.eclipse.ui.model.WorkbenchLabelProvider;
 import org.eclipse.thym.core.HybridCore;
@@ -146,7 +146,6 @@ public class AndroidSimOptionsTab extends AbstractLaunchConfigurationTab {
 		if(!SDKLocationHelper.defineSDKLocationIfNecessary()){
 			setErrorMessage("Android SDK location is not defined" );
 		}
-		
 		String projectName =null;
 		try {
 			projectName = configuration.getAttribute(HybridProjectLaunchConfigConstants.ATTR_BUILD_SCOPE, (String)null);
@@ -198,12 +197,16 @@ public class AndroidSimOptionsTab extends AbstractLaunchConfigurationTab {
 	
 	@Override
 	public boolean isValid(ILaunchConfiguration launchConfig) {
-		return isTabValid() && SDKLocationHelper.isSDKLocationDefined() && super.isValid(launchConfig);
+		return isTabValid() && AndroidCore.getSDKLocation()!=null && super.isValid(launchConfig);
 	}
 
 	private boolean isTabValid() {
 		setMessage(null);
 		setErrorMessage(null);
+		if(AndroidCore.getSDKLocation() == null){
+			setErrorMessage("Android SDK location is not defined" );
+			return false;
+		}
 		String avd = AVDCombo.getText();
 		if(avd != null && !avd.isEmpty()){
 			AndroidAPILevelComparator alc = new AndroidAPILevelComparator();

--- a/plugins/org.eclipse.thym.android.ui/src/org/eclipse/thym/android/ui/SDKLocationHelper.java
+++ b/plugins/org.eclipse.thym.android.ui/src/org/eclipse/thym/android/ui/SDKLocationHelper.java
@@ -13,7 +13,6 @@ package org.eclipse.thym.android.ui;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.thym.android.core.AndroidConstants;
 import org.eclipse.thym.android.core.AndroidCore;
-import org.eclipse.thym.android.ui.internal.preferences.AndroidPreferences;
 import org.eclipse.thym.android.ui.internal.statushandler.MissingSDKStatusHandler;
 import org.eclipse.thym.core.HybridMobileStatus;
 /**
@@ -25,23 +24,12 @@ import org.eclipse.thym.core.HybridMobileStatus;
 public class SDKLocationHelper {
 	
 	public static boolean defineSDKLocationIfNecessary(){
-		if(isSDKLocationDefined())
+		if(AndroidCore.getSDKLocation() != null){
 			return true;
+		}
 		MissingSDKStatusHandler handler = new MissingSDKStatusHandler();
 		handler.handle(makeNoSDKLocationStatus());
-		return isSDKLocationDefined();
-	}
-	
-	public static String getSDKLocation()
-	{
-		if(isSDKLocationDefined())
-			return  AndroidPreferences.getPrefs().getAndroidSDKLocation();
-		return null;
-	}
-
-	public static boolean isSDKLocationDefined() {
-		String sdkLocation = AndroidPreferences.getPrefs().getAndroidSDKLocation();
-		return (sdkLocation != null && sdkLocation.length()>0);
+		return AndroidCore.getSDKLocation() != null;
 	}
 	
 	public static HybridMobileStatus makeNoSDKLocationStatus(){

--- a/plugins/org.eclipse.thym.android.ui/src/org/eclipse/thym/android/ui/internal/preferences/AndroidPreferencePage.java
+++ b/plugins/org.eclipse.thym.android.ui/src/org/eclipse/thym/android/ui/internal/preferences/AndroidPreferencePage.java
@@ -17,6 +17,7 @@ import org.eclipse.jface.preference.DirectoryFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.thym.android.core.AndroidConstants;
+import org.eclipse.thym.android.core.AndroidCore;
 import org.eclipse.thym.ui.HybridUI;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
@@ -53,6 +54,10 @@ public class AndroidPreferencePage
 			String filename = getTextControl().getText();
 			filename = filename.trim();
 			if(filename.isEmpty()){
+				if(AndroidCore.getSDKLocation() != null){
+					getTextControl().setMessage(AndroidCore.getSDKLocation());
+					return true;
+				}
 				this.getPage().setMessage("A location for the Android SDK must be specified", IStatus.WARNING);
 				return true;
 			}else{


### PR DESCRIPTION
Android SDK from preferences takes precedence over ANDROID_HOME env var.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=491430
Signed-off-by: Rastislav Wagner <rawagner@redhat.com>