### PR TITLE
[491764] Exitting cordova CLI may result in exception if process is a…

### DIFF
--- a/plugins/org.eclipse.thym.core/src/org/eclipse/thym/core/internal/cordova/CordovaCLI.java
+++ b/plugins/org.eclipse.thym.core/src/org/eclipse/thym/core/internal/cordova/CordovaCLI.java
@@ -174,7 +174,14 @@ public class CordovaCLI {
 			streamProxy.write(cordovaCommand.toString());
 			while (!process.isTerminated()) {
 				//exit the shell after sending the command
-				streamProxy.write("exit\n");
+				try{
+					streamProxy.write("exit\n");
+				} catch (IOException e) {
+					if(process.isTerminated()){ //ok, if process is terminated
+						break;
+					}
+					throw e;
+				}
 				if (monitor.isCanceled()) {
 					process.terminate();
 					break;


### PR DESCRIPTION
…lready terminated.

Bug: https://bugs.eclipse.org/bugs/show_bug.cgi?id=491764
Signed-off-by: Rastislav Wagner <rawagner@redhat.com>